### PR TITLE
feature: Add support for HTTP method PATCH

### DIFF
--- a/consts.js
+++ b/consts.js
@@ -2,6 +2,7 @@ const HTTP_GET      = "GET";
 const HTTP_POST     = "POST";
 const HTTP_DELETE   = "DELETE";
 const HTTP_PUT      = "PUT";
+const HTTP_PATCH    = "PATCH";
 const LOG_LEVEL     = "debug";
 
 module.exports = {
@@ -9,5 +10,6 @@ module.exports = {
     HTTP_POST: HTTP_POST,
     HTTP_DELETE: HTTP_DELETE,
     HTTP_PUT: HTTP_PUT,
+    HTTP_PATCH: HTTP_PATCH,
     LOG_LEVEL: LOG_LEVEL
 };

--- a/index.js
+++ b/index.js
@@ -138,7 +138,13 @@ function constructRoute(endpoint) {
                 endpoint.config.implementation(endpoint.apiVersion, req, res, next);
             });
             break;
-        default:
+        case consts.HTTP_PATCH:
+            winston.debug('Adding route \'' + endpoint.config.method, ' /' + endpoint.apiVersion + endpoint.config.route + '\'');
+            router.patch('/' + endpoint.apiVersion + endpoint.config.route, function(req, res, next) {
+                endpoint.config.implementation(endpoint.apiVersion, req, res, next);
+            });
+            break;
+         default:
             winston.debug('HTTP Method not recognised! Not adding endpoint \'' + endpoint.config.method, ' /' + endpoint.apiVersion + endpoint.config.route + '\'');
     }
 }


### PR DESCRIPTION
This adds support for the commonly used HTTP method/verb PATCH. Ideally totoro should just pass the verb along to express since express has support for a wide variety of verbs, but PATCH seemed like a so commonly used one that at least that should be supported.